### PR TITLE
Adding users search wrapper

### DIFF
--- a/src/twitter.clj
+++ b/src/twitter.clj
@@ -571,6 +571,15 @@ take any required and optional arguments and call the associated Twitter method.
   []
   (comp #(:content %) status-handler))
 
+(def-twitter-method users-search
+  :get
+  "api.twitter.com/1/users/search.json"
+  [:q]
+  [:page
+   :per_page
+   :include_entities]
+  (comp #(:content %) status-handler))
+
 (def-twitter-method search
   :get
   "search.twitter.com/search.json"


### PR DESCRIPTION
The /users/search.json allows for searching of users on twitter. The added users-search wrapper adds support for features defined in the API documentation.

API reference: https://dev.twitter.com/docs/api/1/get/users/search
